### PR TITLE
optimized the native share button for tablets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [1.3.2] - 2022-02-18
+### Changed
+- optimized the native share button for tablets
+
 ## [1.3.1] - 2021-08-12
 ### Fixed
 - addToCart ignored quantity

--- a/frontend/portals/Media/index.jsx
+++ b/frontend/portals/Media/index.jsx
@@ -74,7 +74,7 @@ css.global('.tablet-right-column .price ui-shared__price', {
   fontSize: '1.7rem',
 });
 
-const NATIVE_SHARE_BUTTON = 'product.tablet.right-column.ctas';
+const PRODUCT_TABLET_RIGHT_COLUMN_CTAS = 'product.tablet.right-column.ctas';
 
 /**
  * Media component
@@ -119,7 +119,7 @@ const Media = ({ children, isTablet }) => {
                   <AddToFavlist
                     productId={productId}
                   />
-                  <Portal name={NATIVE_SHARE_BUTTON} />
+                  <Portal name={PRODUCT_TABLET_RIGHT_COLUMN_CTAS} />
                 </div>
               </div>
             )}

--- a/frontend/portals/Media/index.jsx
+++ b/frontend/portals/Media/index.jsx
@@ -7,6 +7,7 @@ import ProductUnitQuantityPicker
   from '@shopgate/engage/product/components/UnitQuantityPicker/ProductUnitQuantityPicker';
 import OrderQuantityHint
   from '@shopgate/engage/product/components/OrderQuantityHint';
+import { Portal } from '@shopgate/engage/components';
 import MediaColumnContext from '../MediaColumnContext';
 import connectIsTablet from '../connector';
 import AddToCartButton from './components/AddToCartButton';
@@ -39,6 +40,10 @@ const styles = {
     padding: 16,
     ...(colorPdpBox && { backgroundColor: colorPdpBox }),
   }).toString(),
+  ctaWrapperInner: css({
+    display: 'flex',
+    alignItems: 'center',
+  }).toString(),
   rightBox: css({
     padding: '0 32px',
   }).toString(),
@@ -68,6 +73,8 @@ css.global('.tablet-right-column .theme__product__header__product-info__row2', {
 css.global('.tablet-right-column .price ui-shared__price', {
   fontSize: '1.7rem',
 });
+
+const NATIVE_SHARE_BUTTON = 'product.tablet.right-column.ctas';
 
 /**
  * Media component
@@ -108,9 +115,12 @@ const Media = ({ children, isTablet }) => {
                   options={options}
                   productId={variantId || productId}
                 />
-                <AddToFavlist
-                  productId={productId}
-                />
+                <div className={styles.ctaWrapperInner}>
+                  <AddToFavlist
+                    productId={productId}
+                  />
+                  <Portal name={NATIVE_SHARE_BUTTON} />
+                </div>
               </div>
             )}
           </ProductContext.Consumer>


### PR DESCRIPTION
# Pull Request Template

## Description

Added the functionality, that the share button is shown next to the "add to favorites" button, if the tablet-adjustment-extension is enabled.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
